### PR TITLE
Fixes code-block typo to render sql code on http://www.postgresguide.com/setup/users.html

### DIFF
--- a/source/setup/users.rst
+++ b/source/setup/users.rst
@@ -6,7 +6,7 @@ Adding a User
 
 Once you've initially installed Postgres you should be able to connect almost immediately with `psql -h localhost`. This will put you inside your database to begin working. Of course the next step before doing anything else is to create a user account for yourself.
 
-.. code::SQL
+.. code-block:: SQL
 
    craig=# CREATE USER craig WITH PASSWORD 'Password';
    CREATE ROLE


### PR DESCRIPTION
I noticed that the SQL code for creating a user was missing from the rendered page. This patch fixes that (but not the TBD explain what it means :stuck_out_tongue: )
