### PR TITLE
fix footer link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: Postgres Guide
 twitter_username: postgresguide
 twitter_tweet_button: true
-github_username: postgresguide
+github_username: craigkerstiens/postgresguide.com
 destination:    ./_site
 safe:           false
 lsi:            false


### PR DESCRIPTION
github.com/postgresguide isn't a real thing