### PR TITLE
Fix toggling nav, add show previous/next doc in collections

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,10 +16,12 @@
         <div id="post-nav">
           {% assign alldocs = "" | split: "" %}
           {% for collection in site.collections %}
-            {% capture label %}{{ collection | first }}{% endcapture %}
-            {% for doc in site.collections.[label].docs %}
-              {% assign alldocs = alldocs | push: doc %}
-            {% endfor %}
+            {% if collection[1].output %}
+              {% capture label %}{{ collection | first }}{% endcapture %}
+              {% for doc in site.collections.[label].docs %}
+                {% assign alldocs = alldocs | push: doc %}
+              {% endfor %}
+            {% endif %}
           {% endfor %}
 
           {% for doc in alldocs %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,6 +13,37 @@
         <div class="post">
           {{ content }}
         </div>
+        <div id="post-nav">
+          {% assign alldocs = "" | split: "" %}
+          {% for collection in site.collections %}
+            {% capture label %}{{ collection | first }}{% endcapture %}
+            {% for doc in site.collections.[label].docs %}
+              {% assign alldocs = alldocs | push: doc %}
+            {% endfor %}
+          {% endfor %}
+
+          {% for doc in alldocs %}
+            {% if doc.title == page.title %}
+              {% unless forloop.last %}
+                {% assign next = alldocs[forloop.index] %}
+                {% if next.url %}
+                  {% assign nexturl = next.url %}
+                  {% assign nexttitle = next.title %}
+                {% endif %}
+              {% endunless %}
+              {% unless forloop.first %}
+                {% if prev.url %}
+                  {% assign prevurl = prev.url %}
+                  {% assign prevtitle = prev.title %}
+                {% endif %}
+              {% endunless %}
+            {% endif %}
+            {% assign prev =  doc %}
+          {% endfor %}
+
+          {% if prevurl %}<p>Previous: <a href="{{prevurl}}" class="prev">{{prevtitle}}</a></p>{% endif %} 
+          {% if nexturl %}<p>Next: <a href="{{nexturl}}" class="next">{{nexttitle}}</a></p>{% endif %}
+        </div>
       </div>
     </div>
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -59,6 +59,10 @@
             padding-top: 10px;
             text-align: center;
 
+            &:active {
+                -webkit-tap-highlight-color: rgba(0,0,0,0); //remove gray highlight in Mobile Safari
+            }
+
             > svg {
                 width: 18px;
                 height: 15px;
@@ -72,11 +76,11 @@
         .trigger {
             clear: both;
             display: none;
-        }
 
-        &:hover .trigger {
-            display: block;
-            padding-bottom: 5px;
+            &.expanded {
+                display: block;
+                padding-bottom: 5px;
+            }
         }
 
         .page-link {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -9,4 +9,18 @@ $(document).ready(function(){
     $(".side li a.active ~ nav").append("<li class='tag-" + this.nodeName.toLowerCase() + "'><a href='#" +           $(this).text().toLowerCase().replace(/ /g, '-').replace(/[^\w-]+/g,'') + "'>" + $(this).text() + "</a></li>");
     $(this).attr("id",$(this).text().toLowerCase().replace(/ /g, '-').replace(/[^\w-]+/g,''));
   });
+
+  var $elSiteNav = $('.site-nav');
+  $elSiteNav.on('touchstart', function(e) {
+  	$('.trigger').addClass('expanded');
+  });
+  $elSiteNav.on('mouseenter mouseleave', function(e) {
+  	$('.trigger').toggleClass('expanded');
+  });
+  $('body').on('click touchstart', function(e) {
+  	if (!$elSiteNav.is(e.target) && $elSiteNav.has(e.target).length === 0) {
+        $('.trigger').removeClass('expanded');
+    }
+  });
+
 });


### PR DESCRIPTION
Getting next/previous document from multiple collections is hairy - as long as your collections are listed in the nav in the same order that they're defined in the `_config.yml`, this should work fine. I'll leave the styling to you. :smile:

Also, the mobile menu behaves as expected on mobile browsers.
