### PR TITLE
Add note on starting the server

### DIFF
--- a/_setup/001-install.md
+++ b/_setup/001-install.md
@@ -17,6 +17,7 @@ For Linux
 ### For APT systems (Ubuntu, Debian, Mint, Etc)
 
     sudo apt-get install postgresql
+    sudo service postgresql start
 
 ### For Arch Linux
 


### PR DESCRIPTION
On Ubuntu, a server isn't necessarily started by installing it. Instructions on starting it took a few minutes due to platform differences, but in the end it came down to this.

Tested on a blank [c9](https://c9.io) server.
