### PR TITLE
Create postgres docker image for use with postgresguide.com

### DIFF
--- a/_setup/001-install.md
+++ b/_setup/001-install.md
@@ -5,6 +5,22 @@ date:
 categories: setup
 permalink: /setup/install.html
 ---
+For Docker
+----------
+```
+# clone repo and cd to docker assets directory
+git clone https://github.com/craigkerstiens/postgresguide.com.git
+cd postgresguide.com/assets/docker
+
+# run postgres setup script
+./setup_postgres.sh
+
+# login to postgres terminal (as "postgres" user, see Dockerfile)
+docker exec -it some-postgres psql --dbname pgguide
+
+# confirm that tables have been loaded
+pgguide=# \d
+```
 
 For Mac
 -------

--- a/assets/docker/Dockerfile
+++ b/assets/docker/Dockerfile
@@ -1,0 +1,10 @@
+FROM postgres
+
+MAINTAINER Mike Situ (github.com/shola)
+
+USER postgres
+ENV POSTGRES_USER postgres
+ENV POSTGRES_PASSWORD changeme
+
+ADD example.dump /tmp/example.dump
+ADD load_sample_data.sh /docker-entrypoint-initdb.d/

--- a/assets/docker/load_sample_data.sh
+++ b/assets/docker/load_sample_data.sh
@@ -1,0 +1,4 @@
+#~/bin/bash
+
+createdb pgguide
+pg_restore --no-owner --dbname pgguide /tmp/example.dump

--- a/assets/docker/setup_postgres.sh
+++ b/assets/docker/setup_postgres.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# convenience functions for removing all running/exited containers
+# add these to your ~/.bash_profile if desired:
+#   alias rmrfDockerContainers="docker stop $(docker ps -a -q) && docker rm $(docker ps -a -q)"
+#   alias rmrfDockerImages="docker rmi $(docker images)"
+
+# curl example data
+curl -L -O http://cl.ly/173L141n3402/download/example.dump
+
+# build postgres image
+docker build . -t mypostgres:latest
+
+# run postgres in the background
+docker run --name some-postgres mypostgres -d postgres
+
+# login to postgres terminal (as "postgres" user)
+docker exec -it some-postgres psql --dbname pgguide


### PR DESCRIPTION
This PR provides a Dockerfile and some helper scripts to setup the test data from postgresguide.com in a Docker container.

I followed the format of the 001-install.md closely, but I'm happy to make formatting changes if asked.

For more info, see the official documentation: https://hub.docker.com/_/postgres/